### PR TITLE
using correct data type of unit32_t for colour values

### DIFF
--- a/Shelf_Edge_Clock_V1/Shelf_Edge_Clock_V1.ino
+++ b/Shelf_Edge_Clock_V1/Shelf_Edge_Clock_V1.ino
@@ -52,14 +52,16 @@ DateTime MyDateAndTime;
 #define LEDCLOCK_COUNT 216
 #define LEDDOWNLIGHT_COUNT 12
 
-  //(red * 65536) + (green * 256) + blue ->for 32-bit merged colour value so 16777215 equals white
-int clockMinuteColour = 51200; //1677
-int clockHourColour = 140000000; //7712
+//(red * 65536) + (green * 256) + blue ->for 32-bit merged colour value so 16777215 equals white
+// or 3 hex byte 00 -> ff for RGB eg 0x123456 for red=12(hex) green=34(hex), and green=56(hex) 
+// this hex method is the same as html colour codes just with "0x" instead of "#" in front
+uint32_t clockMinuteColour = 0x800000; // pure red 
+uint32_t clockHourColour = 0x008000;   // pure green
 
 int clockFaceBrightness = 0;
 
 // Declare our NeoPixel objects:
-Adafruit_NeoPixel stripClock(LEDCLOCK_COUNT, LEDCLOCK_PIN, NEO_RGB + NEO_KHZ800);
+Adafruit_NeoPixel stripClock(LEDCLOCK_COUNT, LEDCLOCK_PIN, NEO_GRB + NEO_KHZ800);
 Adafruit_NeoPixel stripDownlighter(LEDDOWNLIGHT_COUNT, LEDDOWNLIGHT_PIN, NEO_GRB + NEO_KHZ800);
 // Argument 1 = Number of pixels in NeoPixel strip
 // Argument 2 = Arduino pin number (most are valid)
@@ -204,7 +206,7 @@ void displayTheTime(){
   }
 
 
-void displayNumber(int digitToDisplay, int offsetBy, int colourToUse){
+void displayNumber(int digitToDisplay, int offsetBy, uint32_t colourToUse){
     switch (digitToDisplay){
     case 0:
     digitZero(offsetBy,colourToUse);

--- a/Shelf_Edge_Clock_V1/digits.ino
+++ b/Shelf_Edge_Clock_V1/digits.ino
@@ -1,46 +1,46 @@
-void digitZero(int offset, int colour){
+void digitZero(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 27);
     stripClock.fill(colour, (36 + offset), 27);
 }
 
-void digitOne(int offset, int colour){
+void digitOne(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 9);
     stripClock.fill(colour, (36 + offset), 9);
 }
 
-void digitTwo(int offset, int colour){
+void digitTwo(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 18);
     stripClock.fill(colour, (27 + offset), 9);
     stripClock.fill(colour, (45 + offset), 18);
 }
 
-void digitThree(int offset, int colour){
+void digitThree(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 18);
     stripClock.fill(colour, (27 + offset), 27);
 }
 
-void digitFour(int offset, int colour){
+void digitFour(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 9);
     stripClock.fill(colour, (18 + offset), 27);
 }
 
-void digitFive(int offset, int colour){
+void digitFive(int offset, uint32_t colour){
     stripClock.fill(colour, (9 + offset), 45);
 }
 
-void digitSix(int offset, int colour){
+void digitSix(int offset, uint32_t colour){
     stripClock.fill(colour, (9 + offset), 54);
 }
 
-void digitSeven(int offset, int colour){
+void digitSeven(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 18);
     stripClock.fill(colour, (36 + offset), 9);
 }
 
-void digitEight(int offset, int colour){
+void digitEight(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 63);
 }
 
-void digitNine(int offset, int colour){
+void digitNine(int offset, uint32_t colour){
     stripClock.fill(colour, (0 + offset), 45);
 }


### PR DESCRIPTION
the previous type of int is only 16bit and cannot hold the 24bit of colour info. The effect is that the most significant colour (red here) is trimmed off, and can't display any red. Same for the param type of displayNumber(). 

Also we are changing the comms type from RGB to GRB...we suspect that this previously a hack to get around above loss of color bits. Clearly the clockFace and Downlight comms mode should be the same. They came from the same strip of LEDs

Need second commit to change param types in digit functions